### PR TITLE
Move deploy to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Deploy site
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+railsgirls.com


### PR DESCRIPTION
Move the deploy to GitHub Pages so that it will be easier to deploy it with updates. Use GitHub Actions for the deploy to allow for more flexibility in the future.

As far as I'm aware no scheduled build is needed to update the website. It's most likely used now, as the server hosting the website is not setup to receive GitHub webhooks to trigger deploys.

I found one dynamic website section, the events list on the index page. This is updated using JavaScript loading the `events.json` file.

For this change to be merged the domain DNS needs to be updated to point to GitHub Pages, like it does for the guides.railsgirls.com website.

Resolves: #2163 
Resolves: #2093 
Status: Blocked on DNS changes and decision on the [deploy method](https://github.com/railsgirls/railsgirls/pull/2164#issuecomment-1492879111).